### PR TITLE
fix pulumi up

### DIFF
--- a/api/_examples/apollo-server-express-api.ts
+++ b/api/_examples/apollo-server-express-api.ts
@@ -2,14 +2,14 @@
  * API from https://www.apollographql.com/docs/apollo-server/features/subscriptions#middleware
  */
 import { ApolloServer } from "apollo-server-express";
-import express from "express";
+import * as express from "express";
 import {
   IStoredConnection,
   IStoredPubSubSubscription,
 } from "fanout-graphql-tools";
 import { GraphqlWsOverWebSocketOverHttpExpressMiddleware } from "fanout-graphql-tools";
 import { MapSimpleTable } from "fanout-graphql-tools";
-import http from "http";
+import * as http from "http";
 import FanoutGraphqlApolloConfig, {
   FanoutGraphqlGripChannelsForSubscription,
 } from "../_lib/FanoutGraphqlApolloConfig";

--- a/api/_lib/FanoutGraphqlApolloConfig.ts
+++ b/api/_lib/FanoutGraphqlApolloConfig.ts
@@ -22,8 +22,8 @@ import { withFilter } from "graphql-subscriptions";
 import gql from "graphql-tag";
 import { IResolvers, makeExecutableSchema } from "graphql-tools";
 import { $$asyncIterator } from "iterall";
-import querystring from "querystring";
-import uuidv4 from "uuid/v4";
+import * as querystring from "querystring";
+import * as uuidv4 from "uuid/v4";
 
 /** Common queries for this API */
 export const FanoutGraphqlSubscriptionQueries = {
@@ -342,13 +342,11 @@ export const FanoutGraphqlApolloConfig = (
 
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 
-  interface ISubscriptionContextOptions {
-    /** graphql context to use for subscription */
-    context: Context;
-  }
-
   const createContext = async (
-    contextOptions: ExpressContext | ISubscriptionContextOptions,
+    contextOptions: ExpressContext | {
+      /** graphql context to use for subscription */
+      context: Context;
+    },
   ): Promise<IFanoutGraphqlAppContext> => {
     // console.log("FanoutGraphqlApolloConfig createContext with contextOptions");
     const connectionContext =

--- a/api/_lib/FanoutGraphqlAppLambdaCallback.ts
+++ b/api/_lib/FanoutGraphqlAppLambdaCallback.ts
@@ -1,9 +1,9 @@
-import aws from "@pulumi/aws";
-import awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
 import { PubSubEngine } from "apollo-server";
 import { APIGatewayProxyEvent } from "aws-lambda";
-import AWSLambda from "aws-lambda";
-import awsServerlessExpress from "aws-serverless-express";
+import * as AWSLambda from "aws-lambda";
+import * as awsServerlessExpress from "aws-serverless-express";
 import { compose } from "fp-ts/lib/function";
 import { IFanoutGraphqlTables } from "./FanoutGraphqlApolloConfig";
 import {

--- a/api/_lib/FanoutGraphqlAppLambdaCallbackTest.test.ts
+++ b/api/_lib/FanoutGraphqlAppLambdaCallbackTest.test.ts
@@ -1,5 +1,5 @@
-import pulumiAws from "@pulumi/aws";
-import pulumiAwsx from "@pulumi/awsx";
+import * as pulumiAws from "@pulumi/aws";
+import * as pulumiAwsx from "@pulumi/awsx";
 import { AsyncTest, Expect, FocusTest, TestFixture } from "alsatian";
 import { APIGatewayProxyEvent, Handler } from "aws-lambda";
 import { MapSimpleTable } from "fanout-graphql-tools";
@@ -8,10 +8,10 @@ import {
   encodeWebSocketEvents,
   WebSocketEvent,
 } from "grip";
-import LambdaTester from "lambda-tester";
+import * as LambdaTester from "lambda-tester";
+import { cli } from "../_test/cli";
 import { INote } from "./FanoutGraphqlApolloConfig";
 import FanoutGraphqlAppLambdaCallback from "./FanoutGraphqlAppLambdaCallback";
-import { cli } from "../_test/cli";
 
 /** Convert a pulumi aws.lambda.Callback to a handler function that can be used with lambda-tester. The types are slightly different */
 const PulumiCallbackForLambdaTester = (

--- a/api/_lib/FanoutGraphqlExpressServer.ts
+++ b/api/_lib/FanoutGraphqlExpressServer.ts
@@ -6,14 +6,14 @@ import {
 } from "apollo-server-express";
 import { getMainDefinition } from "apollo-utilities";
 import * as bodyParser from "body-parser";
-import express from "express";
+import * as express from "express";
 import { MapSimpleTable } from "fanout-graphql-tools";
 import { GraphqlWsOverWebSocketOverHttpExpressMiddleware } from "fanout-graphql-tools";
 import gql from "graphql-tag";
 import * as http from "http";
 import { ConnectionContext } from "subscriptions-transport-ws";
 import { format as urlFormat } from "url";
-import WebSocket from "ws";
+import * as WebSocket from "ws";
 import FanoutGraphqlApolloConfig, {
   FanoutGraphqlGripChannelsForSubscription,
   IFanoutGraphqlTables,

--- a/api/_lib/FanoutGraphqlExpressServerTest.test.ts
+++ b/api/_lib/FanoutGraphqlExpressServerTest.test.ts
@@ -13,11 +13,17 @@ import {
   IStoredPubSubSubscription,
   MapSimpleTable,
 } from "fanout-graphql-tools";
-import http from "http";
-import killable from "killable";
+import * as http from "http";
+import * as killable from "killable";
 import { AddressInfo } from "net";
-import url from "url";
-import WebSocket from "ws";
+import * as url from "url";
+import * as WebSocket from "ws";
+import { cli, DecorateIf } from "../_test/cli";
+import {
+  FanoutGraphqlHttpAtUrlTest,
+  itemsFromLinkObservable,
+  timer,
+} from "../_test/testFanoutGraphqlAtUrl";
 import {
   FanoutGraphqlSubscriptionQueries,
   INote,
@@ -26,12 +32,6 @@ import {
   apolloServerInfo,
   FanoutGraphqlExpressServer,
 } from "./FanoutGraphqlExpressServer";
-import { cli, DecorateIf } from "../_test/cli";
-import {
-  FanoutGraphqlHttpAtUrlTest,
-  itemsFromLinkObservable,
-  timer,
-} from "../_test/testFanoutGraphqlAtUrl";
 import WebSocketApolloClient from "./WebSocketApolloClient";
 
 const hostOfAddressInfo = (address: AddressInfo): string => {

--- a/api/_lib/WebSocketApolloClient.ts
+++ b/api/_lib/WebSocketApolloClient.ts
@@ -5,7 +5,7 @@ import { createHttpLink } from "apollo-link-http";
 import { WebSocketLink } from "apollo-link-ws";
 import { getMainDefinition } from "apollo-utilities";
 import fetch from "cross-fetch";
-import WebSocket from "ws";
+import * as WebSocket from "ws";
 import { IApolloServerUrlInfo } from "./FanoutGraphqlExpressServer";
 
 const WebSocketApolloClient = ({

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
-import FanoutGraphqlAwsApp from "./FanoutGraphqlAwsApp";
+import FanoutGraphqlAwsApp from "./api/_lib/FanoutGraphqlAwsApp";
 
 const pulumiConfig = new pulumi.Config("fanout.io-lambda-demo");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,19 +140,23 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -160,11 +164,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -172,50 +178,61 @@
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
             },
             "fs-minipass": {
               "version": "1.2.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
               "requires": {
                 "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -229,25 +246,29 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
             },
             "iconv-lite": {
               "version": "0.4.23",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "requires": {
                 "minimatch": "^3.0.4"
               }
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -255,37 +276,44 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             },
             "minipass": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -293,27 +321,31 @@
             },
             "minizlib": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "requires": {
                 "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
                 "minimist": "0.0.8"
               },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "needle": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -322,20 +354,23 @@
               "dependencies": {
                 "debug": {
                   "version": "3.2.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                   "requires": {
                     "ms": "^2.1.1"
                   }
                 },
                 "ms": {
                   "version": "2.1.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
               }
             },
             "node-pre-gyp": {
               "version": "0.13.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -351,7 +386,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -359,11 +395,13 @@
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
             },
             "npm-packlist": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1"
@@ -371,7 +409,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -381,30 +420,36 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -412,11 +457,13 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
             },
             "protobufjs": {
               "version": "5.0.3",
@@ -431,7 +478,8 @@
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -441,7 +489,8 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -454,14 +503,16 @@
             },
             "rimraf": {
               "version": "2.6.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "requires": {
                 "glob": "^7.1.3"
               },
               "dependencies": {
                 "glob": {
                   "version": "7.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
                   "requires": {
                     "fs.realpath": "^1.0.0",
                     "inflight": "^1.0.4",
@@ -475,31 +526,38 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             },
             "signal-exit": {
               "version": "3.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -508,25 +566,29 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
             },
             "tar": {
               "version": "4.4.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -539,22 +601,26 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
             }
           }
         },
@@ -635,6 +701,80 @@
             "@pulumi/pulumi": "^0.17.23",
             "semver": "^5.4.0"
           }
+        },
+        "@pulumi/pulumi": {
+          "version": "0.17.28",
+          "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
+          "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+          "requires": {
+            "@pulumi/query": "^0.3.0",
+            "deasync": "^0.1.15",
+            "google-protobuf": "^3.5.0",
+            "grpc": "1.21.1",
+            "minimist": "^1.2.0",
+            "normalize-package-data": "^2.4.0",
+            "protobufjs": "^6.8.6",
+            "read-package-tree": "^5.3.1",
+            "require-from-string": "^2.0.1",
+            "semver": "^6.1.0",
+            "source-map-support": "^0.4.16",
+            "ts-node": "^7.0.0",
+            "typescript": "^3.0.0",
+            "upath": "^1.1.0"
+          },
+          "dependencies": {
+            "read-package-tree": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+              "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+              "requires": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.5.13",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+              "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
         }
       }
     },
@@ -644,6 +784,80 @@
       "integrity": "sha512-mRLLjOopEwzNLI+yNOQC9poIcmydEot49V4Fyf7GfAMWHS3HCLt6PjywO8ASl9M1kgI92nQr4lzx7uWxkjqj6A==",
       "requires": {
         "@pulumi/pulumi": "^0.17.4"
+      },
+      "dependencies": {
+        "@pulumi/pulumi": {
+          "version": "0.17.28",
+          "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
+          "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+          "requires": {
+            "@pulumi/query": "^0.3.0",
+            "deasync": "^0.1.15",
+            "google-protobuf": "^3.5.0",
+            "grpc": "1.21.1",
+            "minimist": "^1.2.0",
+            "normalize-package-data": "^2.4.0",
+            "protobufjs": "^6.8.6",
+            "read-package-tree": "^5.3.1",
+            "require-from-string": "^2.0.1",
+            "semver": "^6.1.0",
+            "source-map-support": "^0.4.16",
+            "ts-node": "^7.0.0",
+            "typescript": "^3.0.0",
+            "upath": "^1.1.0"
+          }
+        },
+        "read-package-tree": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+          "requires": {
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.5.13",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+              "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
       }
     },
     "@pulumi/cloud-aws": {
@@ -659,6 +873,82 @@
         "aws-serverless-express": "^3.3.5",
         "mime": "^2.0.3",
         "semver": "^5.4.0"
+      },
+      "dependencies": {
+        "@pulumi/pulumi": {
+          "version": "0.17.28",
+          "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
+          "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+          "requires": {
+            "@pulumi/query": "^0.3.0",
+            "deasync": "^0.1.15",
+            "google-protobuf": "^3.5.0",
+            "grpc": "1.21.1",
+            "minimist": "^1.2.0",
+            "normalize-package-data": "^2.4.0",
+            "protobufjs": "^6.8.6",
+            "read-package-tree": "^5.3.1",
+            "require-from-string": "^2.0.1",
+            "semver": "^6.1.0",
+            "source-map-support": "^0.4.16",
+            "ts-node": "^7.0.0",
+            "typescript": "^3.0.0",
+            "upath": "^1.1.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+          "requires": {
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.5.13",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+              "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
       }
     },
     "@pulumi/docker": {
@@ -668,12 +958,88 @@
       "requires": {
         "@pulumi/pulumi": "^v0.17.0",
         "semver": "^5.4.0"
+      },
+      "dependencies": {
+        "@pulumi/pulumi": {
+          "version": "0.17.28",
+          "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
+          "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+          "requires": {
+            "@pulumi/query": "^0.3.0",
+            "deasync": "^0.1.15",
+            "google-protobuf": "^3.5.0",
+            "grpc": "1.21.1",
+            "minimist": "^1.2.0",
+            "normalize-package-data": "^2.4.0",
+            "protobufjs": "^6.8.6",
+            "read-package-tree": "^5.3.1",
+            "require-from-string": "^2.0.1",
+            "semver": "^6.1.0",
+            "source-map-support": "^0.4.16",
+            "ts-node": "^7.0.0",
+            "typescript": "^3.0.0",
+            "upath": "^1.1.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+          "requires": {
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.5.13",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+              "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
       }
     },
     "@pulumi/pulumi": {
-      "version": "0.17.28",
-      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
-      "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-1.0.0-beta.4.tgz",
+      "integrity": "sha512-1mpUyFwpxFktxQRVULXLOKlHo9IeZPl7SDkkOkx3Syay6DDduvwyfpkf2vFo1b16nT8SaDo854dhuX7EttfEtA==",
       "requires": {
         "@pulumi/query": "^0.3.0",
         "deasync": "^0.1.15",
@@ -1423,6 +1789,23 @@
         "retry": "0.12.0"
       }
     },
+    "aws-lambda": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-0.1.2.tgz",
+      "integrity": "sha1-GbFYUHXfMWeVl7l2pfHe9h8SzO4=",
+      "requires": {
+        "aws-sdk": "^*",
+        "commander": "^2.5.0",
+        "dotenv": "^0.4.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
+          "integrity": "sha1-9vs1E2PC2SIHJFxzeALJq1rhSVo="
+        }
+      }
+    },
     "aws-sdk": {
       "version": "2.489.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.489.0.tgz",
@@ -1625,8 +2008,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2095,19 +2477,23 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -2115,11 +2501,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2127,50 +2515,61 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -2184,25 +2583,29 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -2210,37 +2613,44 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2248,27 +2658,31 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "requires": {
             "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "needle": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
+          "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
           "requires": {
             "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
@@ -2277,20 +2691,23 @@
           "dependencies": {
             "debug": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             }
           }
         },
         "node-pre-gyp": {
           "version": "0.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
+          "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -2306,7 +2723,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -2314,11 +2732,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -2326,7 +2746,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -2336,30 +2757,36 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -2367,11 +2794,13 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "protobufjs": {
           "version": "5.0.3",
@@ -2386,7 +2815,8 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -2396,7 +2826,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2409,14 +2840,16 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "requires": {
             "glob": "^7.1.3"
           },
           "dependencies": {
             "glob": {
               "version": "7.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -2430,31 +2863,38 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2463,25 +2903,29 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -2494,22 +2938,26 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -3577,9 +4025,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.4.tgz",
-      "integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "fanout-apollo-demo",
-  "main": "./api",
   "devDependencies": {
     "@types/node": "latest",
     "prettier": "^1.17.0",
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",
-    "tslint-config-prettier": "^1.18.0"
+    "tslint-config-prettier": "^1.18.0",
+    "typescript": "^3.5.3"
   },
   "dependencies": {
     "@pulumi/aws": "^0.18.20",
     "@pulumi/awsx": "latest",
     "@pulumi/cloud": "^0.18.0",
     "@pulumi/cloud-aws": "^0.18.0",
-    "@pulumi/pulumi": "latest",
+    "@pulumi/pulumi": "^1.0.0-beta.4",
     "@types/core-js": "^2.5.0",
     "@types/graphql": "^14.2.0",
     "@types/lambda-tester": "^3.5.1",
@@ -30,6 +30,7 @@
     "apollo-server-lambda": "^2.4.8",
     "apollo-server-micro": "^2.4.8",
     "apollo-utilities": "^1.3.2",
+    "aws-lambda": "^0.1.2",
     "aws-serverless-express": "^3.3.6",
     "axax": "^0.1.24",
     "body-parser": "^1.18.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,19 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
+    /**
+     * `allowSyntheticDefaultImports` is ONLY enabled because the built apollo-server and apollo-server-express require it to compile.
+     * It's not a good idea to rely on this. If packages don't export a default export, don't import it as if they do.
+     * Relying on this may break ./api/_lib/pulumi. No known pulumi-examples use allowSyntheticDefaultImports or esModuleInterop (https://github.com/pulumi/examples/)
+     */
+    "allowSyntheticDefaultImports": true,
+    /**
+     * This must be explicitly set to false to work with now.sh because it will default it to true otherwise, contrary to typescript's own behaivor
+     * https://github.com/zeit/now/blob/229a62d8b6aeb1f5b19de71d4e7c8733ba9e310d/packages/now-node/src/typescript.ts#L472
+     */
+    "esModuleInterop": false,
     "outDir": "bin",
-    "target": "esnext",
+    "declaration": true,
+    "target": "es5",
     "lib": [
       "dom",
       "es2015.symbol",
@@ -28,6 +39,7 @@
       "*": ["./api/@types/*"]
     }
   },
-  "exclude": ["node_modules/**"],
+  "include": ["api"],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./node_modules/fanout-graphql-tools" }]
 }


### PR DESCRIPTION
This fixes `pulumi up`, which is documented in master as the only way to deploy in a way that subscriptions work. It's cool to also be able to deploy to zeit, but without a data store, the GraphQL Subscriptions don't work in that environment. Only the AWS deployment shows off fanout helping enable GraphQL Subscriptions, so we don't want to break that.

First, why was `pulumi up` breaking? It would just hang. This is because pulumi would go to require the `package.json` `main` path, which @styfle had set to `./api`, which was a script that, when required, ran an async function that never ends.
* As an aside, this is why it's generally a good idea not to have a file have side effects like this when it's required. You can prevent this while still making the file executable by wrapping it in a `if (require.main === module) { /** do work */ }` block.

I really really really tried to get this working while preserving changes @styfle introduced, specifically:
* Not having an index.ts that is the pulumi entrypoint
* Not changing package.json `main` from what @styfle set
* Not reverting "esModuleInterop" back to false from how @styfle enabled it

Here's why, at least for now, this PR does those things:

**index.ts as pulumi entrypoint**

First I tried to set `Pulumi.yaml` `main` key to something like `api/_lib/pulumi.ts` hoping that it would then not use the package.json main (./api).

When I ran `pulumi up`, it complained about not finding a package.json right next to that entrypoint. So then I made it a folder with a package.json.

I think then it complained about not having a tsconfig.json in that folder. I added one that extends from the one in the project root.

Then pulumi up would complain about not being able to serialize all the imports to create a lambda bundle, so I did [this](https://github.com/pulumi/pulumi-aws/issues/249#issuecomment-401563361). Then `pulumi up` would deploy a lambda, but it didn't include any of the npm deps needed at runtime (e.g. aws-serverless-express, apollo-server, I think all of them), which would just manifest as an "INTERNAL SERVER ERROR" when requesting the resulting lambda, but I could see "Module not found" stack traces in cloudwatch logs.

I tried to have this 'subpackage' depend on fanout-apollo-demo via an npm file dependency, which, when `npm install`ed creates a symlink to that file. But pulumi doesn't seem to follow symlinks, so that didn't work.

@jkarneges, what might be a good idea in the long term is to move all the pulumi/aws/lambda stuff into a separate package that depends on apollo-serverless-demo just for FanoutGraphqlExpressApp. It would have to be a new repo, e.g. apollo-lambda-demo-pulumi or something. Then we could npm publish apollo-serverless-demo, the lambda/pulumi repo could npm-depend on that, and there would be no symlinks and it would probably work. But then this repo itself would not have a single command to deploy with working GraphQL Subscriptions, you'd have to go to the other one. This would just be common application logic.

**Unsetting package.json `main` from what @styfle set**

No matter what, `pulumi up` requires this file if it's in the package.json that is next to the Pulumi.yaml#main. It doesn't seem necessary to work on `now`. If we do publish this project to npm after compiling it to js, we'd want to set this to [the tsconfig.json outDir anyway](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) (right now `./bin`), not ./api.

**reverting "esModuleInterop" back to false from how @styfle enabled it**

(False is the typescript default).

If this is true, the lambda pulumi creates throws a ReferenceError at runtime because it can't find `__importStar`, which is what enabling this inserts as a global or something into the built typescript.

Notably, none of the [pulumi examples](https://github.com/pulumi/examples) use esModuleInterop nor allowSyntheticDefaultExports.

The only reason I had set allowSyntheticDefaultExports to true is because the apollo libraries on npm publish javascript that does imports that depend on it, and with it false (the default), our `tsc` fails. shame on apollo.

This whole setting appears only to appease javascripters who want to import a default export from packages/modules *that never had one in the first place*. e.g. `import express from "express"`, even though express' source code only ever does `module.exports = ...`, not `export default ...` or `exports.default ...`. You don't need it. The more accurate way of importing `module.exports` namespaces is `import * as express from "express"`. It works.

Notably, at first I just unset this in tsconfig.json to use the typescript default and reverted the imports back to the `import * as` syntax, and `npm test` worked, the pulumi lambda worked, but when I deployed to `now`, it didn't work. After coming through `now` source code I found this gem: https://github.com/zeit/now-builders/blame/canary/packages/now-node/src/typescript.ts#L472

`now` defaults esModuleInterop to true even though typescript doesn't? smh.

Explicitly setting it to `false` (the default in tsc) in our tsconfig.json avoid that branch and makes it work in now, pulumi/lambda, plus normal tsc defaults + node for `npm test`.